### PR TITLE
Correct bundle identifier

### DIFF
--- a/OpenTerm_Alt.json
+++ b/OpenTerm_Alt.json
@@ -2,7 +2,7 @@
   "apps": [
     {
       "beta": false,
-      "bundleIdentifier": "com.louisdh.openterm",
+      "bundleIdentifier": "com.sliverfox.Terminal",
       "developerName": "louisdh",
       "downloadURL": "https://github.com/onyxware/openterm/releases/download/2.0.1/OpenTerm_Unsigned.ipa",
       "iconURL": "https://raw.githubusercontent.com/louisdh/openterm/master/readme-resources/hero.png",


### PR DESCRIPTION
The bundle identifier extracted from the OpenTerm ipa is `com.silverfox.Terminal`, not `com.louisdh.openterm`.